### PR TITLE
don't install manpages

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,6 +17,8 @@ fi
 
 ./configure \
     --prefix=$PREFIX \
+    --docdir=$PWD/noinst/doc \
+    --mandir=$PWD/noinst/man \
     $build_with_libnl \
     --disable-static \
     --disable-psm3 \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.22.0" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 package:
   name: libfabric
@@ -26,12 +26,14 @@ requirements:
   host:
     - libnl  # [linux]
     - rdma-core  # [linux]
-  run:
 
 test:
   commands:
     - fi_info --version
     - fi_info --list
+    - test ! -f $PREFIX/share/man/man1/fi_info.1
+    - test ! -f $PREFIX/share/man/man3/fi_atomic.3
+    - test ! -f $PREFIX/share/man/man7/fabric.7
 
 about:
   home: http://libfabric.org/


### PR DESCRIPTION
docs are generally packaged separately, and manpages are roughly half of the install size of libfabric.

I could be convinced that man1 (executables) and possibly man7 (misc) should be included, but man3 (C API functions) doesn't really make sense to me.