### PR TITLE
Relax run_exports

### DIFF
--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.22.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: libfabric
@@ -16,7 +16,7 @@ build:
   skip: true  # [win]
 
   run_exports:
-    - {{ pin_subpackage('libfabric', max_pin='x.x') }}
+    - {{ pin_subpackage('libfabric', max_pin='x') }}
 
 requirements:
   build:


### PR DESCRIPTION

the libfabric ABI appears to be quite deliberately forward-compatible, which means we should be able to expect to relax the upper bound to expect a major revision to signal an ABI breakage.

@j34ni this will also help the older versions be more useful, and enable us to do fewer outdated builds

I can also sketch a later PR to actually track the ABI version explicitly.
