### PR TITLE
relax run_exports for ABI 1.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.19.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 package:
   name: libfabric
@@ -19,7 +19,9 @@ build:
   skip: true  # [win or osx]
 
   run_exports:
-    - {{ pin_subpackage('libfabric', max_pin='x') }}
+    # TODO: libfabric 2.0 will likely actually be ABI compatible,
+    # so maybe bump this to 3.0 once 2.0 is released and confirmed to be compatible
+    - libfabric >=1.14.0,<2.0
 
 requirements:
   build:


### PR DESCRIPTION
following tests in #12, 1.19.1 builds are tested to be compatible with 1.14.