### PR TITLE
add `libfabric1` output for ABI tracking

### DIFF
--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libfabric-green.svg)](https://anaconda.org/conda-forge/libfabric) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libfabric.svg)](https://anaconda.org/conda-forge/libfabric) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libfabric.svg)](https://anaconda.org/conda-forge/libfabric) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libfabric.svg)](https://anaconda.org/conda-forge/libfabric) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libfabric--bin-green.svg)](https://anaconda.org/conda-forge/libfabric-bin) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libfabric-bin.svg)](https://anaconda.org/conda-forge/libfabric-bin) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libfabric-bin.svg)](https://anaconda.org/conda-forge/libfabric-bin) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libfabric-bin.svg)](https://anaconda.org/conda-forge/libfabric-bin) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libfabric--devel-green.svg)](https://anaconda.org/conda-forge/libfabric-devel) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libfabric-devel.svg)](https://anaconda.org/conda-forge/libfabric-devel) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libfabric-devel.svg)](https://anaconda.org/conda-forge/libfabric-devel) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libfabric-devel.svg)](https://anaconda.org/conda-forge/libfabric-devel) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libfabric1-green.svg)](https://anaconda.org/conda-forge/libfabric1) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libfabric1.svg)](https://anaconda.org/conda-forge/libfabric1) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libfabric1.svg)](https://anaconda.org/conda-forge/libfabric1) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libfabric1.svg)](https://anaconda.org/conda-forge/libfabric1) |
 
 Installing libfabric
 ====================
@@ -86,16 +89,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `libfabric` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libfabric, libfabric-bin, libfabric-devel, libfabric1` can be installed with `conda`:
 
 ```
-conda install libfabric
+conda install libfabric libfabric-bin libfabric-devel libfabric1
 ```
 
 or with `mamba`:
 
 ```
-mamba install libfabric
+mamba install libfabric libfabric-bin libfabric-devel libfabric1
 ```
 
 It is possible to list all of the versions of `libfabric` available on your platform with `conda`:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,17 @@
 
 set -ex
 
-export CC=$(basename "$CC")
+# verify ABI version
+ABI_LINE=$(grep '#define\s\+CURRENT_ABI' include/ofi_abi.h)
+echo "ABI_LINE=${ABI_LINE}"
+
+CURRENT_ABI=$(echo "$ABI_LINE" | grep -o 'FABRIC_[[:digit:]\.]\+')
+echo "CURRENT_ABI=${CURRENT_ABI}"
+
+if [[ "$CURRENT_ABI" != "FABRIC_$LIBFABRIC_ABI" ]]; then
+  echo "CURRENT_ABI=${CURRENT_ABI} != FABRIC_${$LIBFABRIC_ABI}"
+  exit 1
+fi
 
 build_with_libnl=""
 if [[ "$target_platform" == linux-* ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,10 +3,7 @@
 set -ex
 
 # verify ABI version
-ABI_LINE=$(grep '#define\s\+CURRENT_ABI' include/ofi_abi.h)
-echo "ABI_LINE=${ABI_LINE}"
-
-CURRENT_ABI=$(echo "$ABI_LINE" | grep -o 'FABRIC_[[:digit:]\.]\+')
+CURRENT_ABI=$(cat libfabric.map.in| grep -o '^FABRIC_[[:digit:]\.]\+' | tail -n 1)
 echo "CURRENT_ABI=${CURRENT_ABI}"
 
 if [[ "$CURRENT_ABI" != "FABRIC_$LIBFABRIC_ABI" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,13 @@
 {% set version = "1.22.0" %}
-{% set build = 1 %}
+{% set build = 2 %}
+
+# when abi version bumps, update the lower bound
+# check https://ofiwg.github.io/libfabric/v1.22.0/man/fabric.7.html#abi-changes
+{% set abi_version = "1.7" %}
+{% set abi_lower_bound = "1.20.0" %}
+# libfabric 2.0 is ABI 1.8, abi-compatible with 1.x
+# can't know if 3.0 will break ABI, but assume it _might_
+{% set abi_upper_bound = "3.0.0a0" %}
 
 package:
   name: libfabric
@@ -7,16 +15,16 @@ package:
 
 source:
   url: https://github.com/ofiwg/libfabric/releases/download/v{{ version }}/libfabric-{{ version }}.tar.bz2
-# sha256: 485e6cafa66c9e4f6aa688d2c9526e274c47fda3a783cf1dd8f7c69a07e2d5fe  # 1.20.0
-  sha256: 485e6cafa66c9e4f6aa688d2c9526e274c47fda3a783cf1dd8f7c69a07e2d5fe  # 1.15.2
-# sha256: fc261388848f3cff555bd653f5cb901f6b9485ad285e5c53328b13f0e69f749a  # 1.14.0
+  sha256: 485e6cafa66c9e4f6aa688d2c9526e274c47fda3a783cf1dd8f7c69a07e2d5fe
 
 build:
   number: {{ build }}
   skip: true  # [win]
+  script_env:
+    - LIBFABRIC_ABI={{ abi_version }}
 
   run_exports:
-    - {{ pin_subpackage('libfabric', max_pin='x') }}
+    - libfabric >={{ abi_lower_bound }},<{{ abi_upper_bound }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,6 @@
 # when abi version increments, update the lower bound
 # check https://ofiwg.github.io/libfabric/main/man/fabric.7.html#abi-changes
 {% set soversion = "1" %}
-{% set soversion_full = "1.25.0" %}
 {% set abi_version = "1.7" %}
 {% set abi_lower_bound = "1.20.0" %}
 
@@ -36,9 +35,8 @@ requirements:
 outputs:
   - name: libfabric{{ soversion }}
     files:
-      - lib/libfabric.so.{{ soversion }}  # [linux]
-      - lib/libfabric.so.{{ soversion_full }}  # [linux]
-      - lib/libfabric.{{ soversion }}.dylib  # [osx]
+      - lib/libfabric.so.*  # [linux]
+      - lib/libfabric.*.dylib  # [osx]
     requirements:
       # need everything with run_exports here
       build:
@@ -51,6 +49,7 @@ outputs:
       commands:
         - test -f $PREFIX/lib/libfabric.so.{{ soversion }}  # [linux]
         - test -f $PREFIX/lib/libfabric.{{ soversion }}.dylib  # [osx]
+        - test ! -f $PREFIX/lib/libfabric${SHLIB_EXT}
   
   - name: libfabric
     # empty metapackage for mutual exclusivity and backward-compatiblity

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,15 @@
 {% set version = "1.22.0" %}
 {% set build = 2 %}
 
-# when abi version bumps, update the lower bound
-# check https://ofiwg.github.io/libfabric/v1.22.0/man/fabric.7.html#abi-changes
+# when abi version increments, update the lower bound
+# check https://ofiwg.github.io/libfabric/main/man/fabric.7.html#abi-changes
+{% set soversion = "1" %}
+{% set soversion_full = "1.25.0" %}
 {% set abi_version = "1.7" %}
 {% set abi_lower_bound = "1.20.0" %}
-# libfabric 2.0 is ABI 1.8, abi-compatible with 1.x
-# can't know if 3.0 will break ABI, but assume it _might_
-{% set abi_upper_bound = "3.0.0a0" %}
 
 package:
-  name: libfabric
+  name: libfabric-recipe
   version: {{ version }}
 
 source:
@@ -23,9 +22,6 @@ build:
   script_env:
     - LIBFABRIC_ABI={{ abi_version }}
 
-  run_exports:
-    - libfabric >={{ abi_lower_bound }},<{{ abi_upper_bound }}
-
 requirements:
   build:
     - {{ compiler('c') }}
@@ -37,13 +33,73 @@ requirements:
     - libnl  # [linux]
     - rdma-core  # [linux]
 
-test:
-  commands:
-    - fi_info --version
-    - fi_info --list
-    - test ! -f $PREFIX/share/man/man1/fi_info.1
-    - test ! -f $PREFIX/share/man/man3/fi_atomic.3
-    - test ! -f $PREFIX/share/man/man7/fabric.7
+outputs:
+  - name: libfabric{{ soversion }}
+    files:
+      - lib/libfabric.so.{{ soversion }}  # [linux]
+      - lib/libfabric.so.{{ soversion_full }}  # [linux]
+      - lib/libfabric.{{ soversion }}.dylib  # [osx]
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ stdlib("c") }}
+      host:
+        - libnl  # [linux]
+        - rdma-core  # [linux]
+    test:
+      commands:
+        - test -f $PREFIX/lib/libfabric.so.{{ soversion }}  # [linux]
+        - test -f $PREFIX/lib/libfabric.{{ soversion }}.dylib  # [osx]
+  
+  - name: libfabric
+    # empty metapackage for mutual exclusivity
+    requirements:
+      run:
+        - {{ pin_subpackage("libfabric" ~ soversion, exact=True) }}
+    test:
+      commands:
+        - "true"
+    
+  - name: libfabric-bin
+    files:
+      - bin/
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ stdlib("c") }}
+      host:
+        - {{ pin_subpackage("libfabric" ~ soversion, exact=True) }}
+      run:
+        - {{ pin_subpackage("libfabric", exact=True) }}
+        - {{ pin_subpackage("libfabric" ~ soversion, exact=True) }}
+    test:
+      commands:
+        - fi_info --version
+        - fi_info --list
+
+  - name: libfabric-devel
+    files:
+      - lib/libfabric.so  # [linux]
+      - lib/libfabric.dylib  # [osx]
+      - include/
+      - lib/pkgconfig/
+    build:
+      run_exports:
+        # depending on libfabric ensures mutual exclusivity
+        - libfabric
+        - {{ pin_subpackage("libfabric" ~ soversion, max_pin=None, min_pin=abi_lower_bound) }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libfabric", exact=True) }}
+        - {{ pin_subpackage("libfabric" ~ soversion, exact=True) }}
+    test:
+      requires:
+        - pkg-config
+      commands:
+        - test -f $PREFIX/lib/libfabric${SHLIB_EXT}
+        - test -f $PREFIX/include/rdma/fabric.h
+        - pkg-config --cflags --libs libfabric
+        - pkg-config --validate libfabric
 
 about:
   home: http://libfabric.org/
@@ -53,6 +109,7 @@ about:
   summary: Libfabric is also known as Open Fabrics Interfaces (OFI).
 
 extra:
+  feedstock-name: libfabric
   recipe-maintainers:
     - j34ni
     - minrk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ outputs:
       - lib/libfabric.so.{{ soversion_full }}  # [linux]
       - lib/libfabric.{{ soversion }}.dylib  # [osx]
     requirements:
+      # need everything with run_exports here
       build:
         - {{ compiler("c") }}
         - {{ stdlib("c") }}
@@ -52,7 +53,8 @@ outputs:
         - test -f $PREFIX/lib/libfabric.{{ soversion }}.dylib  # [osx]
   
   - name: libfabric
-    # empty metapackage for mutual exclusivity
+    # empty metapackage for mutual exclusivity and backward-compatiblity
+    # ensures only one libfabric{so} per env
     requirements:
       run:
         - {{ pin_subpackage("libfabric" ~ soversion, exact=True) }}
@@ -61,8 +63,11 @@ outputs:
         - "true"
     
   - name: libfabric-bin
+    # without output.script, glob will match anything in host,
+    # so make sure it only picks up fabric executables
+    # fortunately, these all start with `fi_`
     files:
-      - bin/
+      - bin/fi_*
     requirements:
       build:
         - {{ compiler("c") }}
@@ -74,6 +79,7 @@ outputs:
         - {{ pin_subpackage("libfabric" ~ soversion, exact=True) }}
     test:
       commands:
+        - test -f $PREFIX/bin/fi_info
         - fi_info --version
         - fi_info --list
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,8 +35,9 @@ requirements:
 outputs:
   - name: libfabric{{ soversion }}
     files:
-      - lib/libfabric.so.*  # [linux]
-      - lib/libfabric.*.dylib  # [osx]
+      include:
+        - lib/lib*.so.*  # [linux]
+        - lib/lib*.*.dylib  # [osx]
     requirements:
       # need everything with run_exports here
       build:
@@ -62,11 +63,9 @@ outputs:
         - "true"
     
   - name: libfabric-bin
-    # without output.script, glob will match anything in host,
-    # so make sure it only picks up fabric executables
-    # fortunately, these all start with `fi_`
     files:
-      - bin/fi_*
+      include:
+        - bin/
     requirements:
       build:
         - {{ compiler("c") }}
@@ -84,10 +83,14 @@ outputs:
 
   - name: libfabric-devel
     files:
-      - lib/libfabric.so  # [linux]
-      - lib/libfabric.dylib  # [osx]
-      - include/
-      - lib/pkgconfig/
+      include:
+        - lib/
+        - include/
+        - lib/pkgconfig/
+      exclude:
+        # exclude versioned dylibs in libfabric{so}
+        - lib/lib*.so.*  # [linux]
+        - lib/lib*.*.dylib  # [osx]
     build:
       run_exports:
         # depending on libfabric ensures mutual exclusivity


### PR DESCRIPTION
- adds `libfabric1` output which has the library
- `libfabric-devel` has unversioned `.so` symlink, headers, etc.. This is the package that should be in `host`, and has `run_exports`  on both `libfabric` and `libfabric1`.
- `libfabric-bin` has executables in bin/ (matches ubuntu)
- `libfabric` is an empty metapackage, used only for mutual exclusivity and backward-compatibility so an env cannot have `libfabric1` and future `libfabric2` in the same env, which would _very_ likely be undesirable

The ABI version is checked explicitly during build. This check will fail when the ABI version changes, which will prompt a manual change of the lower bound on `libfabric1` in run_exports, at which point we'll need to re-check https://ofiwg.github.io/libfabric/main/man/fabric.7.html#abi-changes

**update:** now trying to follow suggestions in https://github.com/conda-forge/conda-forge.github.io/issues/2401

