### PR TITLE
Fix abi_version to 1.9 for libfabric 2.5.0 and bad substitution in bu…

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ CURRENT_ABI=$(cat libfabric.map.in| grep -o '^FABRIC_[[:digit:]\.]\+' | tail -n 
 echo "CURRENT_ABI=${CURRENT_ABI}"
 
 if [[ "$CURRENT_ABI" != "FABRIC_$LIBFABRIC_ABI" ]]; then
-  echo "CURRENT_ABI=${CURRENT_ABI} != FABRIC_${$LIBFABRIC_ABI}"
+  echo "CURRENT_ABI=${CURRENT_ABI} != FABRIC_${LIBFABRIC_ABI}"
   exit 1
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 source:
   url: https://github.com/ofiwg/libfabric/releases/download/v{{ version }}/libfabric-{{ version }}.tar.bz2
-  sha256: 13f508e1d770c44f872c4117d9bcbfc102dc9d7532d3292455e0e0e5ef7b3bba
+  sha256: 276019edca708dc0569cf3064a412e395ba7b1883299781caed120594f850995
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
-{% set version = "2.4.0" %}
-{% set build = 1 %}
+{% set version = "2.5.0" %}
+{% set build = 0 %}
 
 # when abi version increments, update the lower bound
 # check https://ofiwg.github.io/libfabric/main/man/fabric.7.html#abi-changes
 {% set soversion = "1" %}
-{% set abi_version = "1.8" %}
+{% set abi_version = "1.9" %}
 {% set abi_lower_bound = "2.0.0" %}
 
 package:


### PR DESCRIPTION
This PR is to update the ABI version to 1.9 for libfabric 2.5.0 and fix a typo in build.sh

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
